### PR TITLE
Auto-offline enhancement with idle support

### DIFF
--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -11,102 +11,123 @@ using System.Linq;
 
 namespace Procurement.Utility
 {
-    class PoeTradeOnlineHelper
-    {
+   class PoeTradeOnlineHelper
+   {
 
-        private static PoeTradeOnlineHelper instance;
-        private System.Timers.Timer refreshTimer;
-        private Uri refreshUri;
+      private static PoeTradeOnlineHelper instance;
+      private System.Timers.Timer refreshTimer;
+      private Uri refreshUri;
 
-        [DllImport("user32.dll")]
-        private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+      [DllImport("user32.dll")]
+      private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct LASTINPUTINFO
-        {
-            public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
-            [MarshalAs(UnmanagedType.U4)]
-            public UInt32 cbSize;
-            [MarshalAs(UnmanagedType.U4)]
-            public UInt32 dwTime;
-        }
+      [StructLayout(LayoutKind.Sequential)]
+      private struct LASTINPUTINFO
+      {
+         public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
+         [MarshalAs(UnmanagedType.U4)]
+         public UInt32 cbSize;
+         [MarshalAs(UnmanagedType.U4)]
+         public UInt32 dwTime;
+      }
 
-        private PoeTradeOnlineHelper()
-        {
-            refreshTimer = new Timer();
-            refreshTimer.Elapsed += (s, e) => { RefreshOnlineStatus(); };
-            refreshTimer.Interval = 30 * 60 * 1000;
-        }
+      private PoeTradeOnlineHelper()
+      {
+         refreshTimer = new Timer();
+         refreshTimer.Elapsed += (s, e) => { RefreshOnlineStatus(); };
+         refreshTimer.Interval = 1 * 60 * 1000;
+      }
 
-        public static PoeTradeOnlineHelper Instance
-        {
-            get
+      public static PoeTradeOnlineHelper Instance
+      {
+         get
+         {
+            if (instance == null)
+               instance = new PoeTradeOnlineHelper();
+
+            return instance;
+         }
+      }
+
+      private bool currentlyOnline;
+      private void RefreshOnlineStatus()
+      {
+         try
+         {
+            Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
+            var idleTime = GetIdleTime();
+
+            if (idleTime >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
             {
-                if (instance == null)
-                    instance = new PoeTradeOnlineHelper();
+               // Prevent from spamming poe.xyz
+               if (currentlyOnline)
+               {
+                  using (var client = new WebClient())
+                  {
+                     var offlineUri = new Uri(refreshUri.OriginalString + "/offline");
+                     var data = new NameValueCollection();
+                     client.UploadValuesAsync(offlineUri, "POST", data);
+                  }
+               }
 
-                return instance;
+               // User is AFK or PoE is not running.
+               currentlyOnline = false;
+               return;
             }
-        }
 
-        private void RefreshOnlineStatus()
-        {
-            try
+            if (!currentlyOnline)
             {
-                Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
-                if(GetIdleTime() >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
-                {
-                    // User is AFK or PoE is not running.
-                    return;
-                }
-                using (var client = new WebClient())
-                {
-                    var data = new NameValueCollection();
-                    client.UploadValuesAsync(refreshUri, "POST", data);
-                }
+               using (var client = new WebClient())
+               {
+                  var data = new NameValueCollection();
+                  client.UploadValuesAsync(refreshUri, "POST", data);
+                  currentlyOnline = true;
+               }
             }
-            catch (Exception ex)
-            {
-                Logger.Log("Error refreshing online status in PoeTradeOnlineHelper: " + ex.ToString());
-            }
-        }
+         }
+         catch (Exception ex)
+         {
+            Logger.Log("Error refreshing online/offline status in PoeTradeOnlineHelper: " + ex.ToString());
+         }
+      }
 
-        private TimeSpan GetIdleTime()
-        {
-            var inputInfo = new LASTINPUTINFO() {
-                cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
-                dwTime = 0
-            };
-            GetLastInputInfo(ref inputInfo);
-            // Allow for TickCount wrap-around.
-            return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - inputInfo.dwTime));
-        }
+      private TimeSpan GetIdleTime()
+      {
+         var inputInfo = new LASTINPUTINFO()
+         {
+            cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
+            dwTime = 0
+         };
+         GetLastInputInfo(ref inputInfo);
+         // Allow for TickCount wrap-around.
+         return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - inputInfo.dwTime));
+      }
 
-        internal void Start()
-        {
-            try
-            {
-                var enabled = Convert.ToBoolean(Settings.UserSettings["PoeTradeRefreshEnabled"]);
+      internal void Start()
+      {
+         try
+         {
+            var enabled = Convert.ToBoolean(Settings.UserSettings["PoeTradeRefreshEnabled"]);
 
-                if (!enabled || refreshTimer.Enabled)
-                    return;
+            if (!enabled || refreshTimer.Enabled)
+               return;
 
-                var poeTradeUrl = Settings.UserSettings["PoeTradeRefreshUrl"];
-                refreshUri = new Uri(poeTradeUrl);
+            var poeTradeUrl = Settings.UserSettings["PoeTradeRefreshUrl"];
+            refreshUri = new Uri(poeTradeUrl);
 
-                refreshTimer.Start();
-                RefreshOnlineStatus();
-            }
-            catch (Exception ex)
-            {
-                Logger.Log("Error starting PoeTradeOnlineHelper: " + ex.ToString());
-                MessageBox.Show("Error refreshing poe.trade online status, ensure you have a valid url entered.", "Error Starting PoeTradeOnlineHelper", MessageBoxButton.OK, MessageBoxImage.Error);
-            }
-        }
+            refreshTimer.Start();
+            RefreshOnlineStatus();
+         }
+         catch (Exception ex)
+         {
+            Logger.Log("Error starting PoeTradeOnlineHelper: " + ex.ToString());
+            MessageBox.Show("Error refreshing poe.trade online status, ensure you have a valid url entered.", "Error Starting PoeTradeOnlineHelper", MessageBoxButton.OK, MessageBoxImage.Error);
+         }
+      }
 
-        internal void Stop()
-        {
-            refreshTimer.Stop();
-        }
-    }
+      internal void Stop()
+      {
+         refreshTimer.Stop();
+      }
+   }
 }

--- a/Procurement/Utility/PoeTradeOnlineHelper.cs
+++ b/Procurement/Utility/PoeTradeOnlineHelper.cs
@@ -11,123 +11,123 @@ using System.Linq;
 
 namespace Procurement.Utility
 {
-   class PoeTradeOnlineHelper
-   {
+    class PoeTradeOnlineHelper
+    {
 
-      private static PoeTradeOnlineHelper instance;
-      private System.Timers.Timer refreshTimer;
-      private Uri refreshUri;
+        private static PoeTradeOnlineHelper instance;
+        private System.Timers.Timer refreshTimer;
+        private Uri refreshUri;
 
-      [DllImport("user32.dll")]
-      private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+        [DllImport("user32.dll")]
+        private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
-      [StructLayout(LayoutKind.Sequential)]
-      private struct LASTINPUTINFO
-      {
-         public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
-         [MarshalAs(UnmanagedType.U4)]
-         public UInt32 cbSize;
-         [MarshalAs(UnmanagedType.U4)]
-         public UInt32 dwTime;
-      }
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LASTINPUTINFO
+        {
+            public static readonly int SizeOf = Marshal.SizeOf(typeof(LASTINPUTINFO));
+            [MarshalAs(UnmanagedType.U4)]
+            public UInt32 cbSize;
+            [MarshalAs(UnmanagedType.U4)]
+            public UInt32 dwTime;
+        }
 
-      private PoeTradeOnlineHelper()
-      {
-         refreshTimer = new Timer();
-         refreshTimer.Elapsed += (s, e) => { RefreshOnlineStatus(); };
-         refreshTimer.Interval = 1 * 60 * 1000;
-      }
+        private PoeTradeOnlineHelper()
+        {
+            refreshTimer = new Timer();
+            refreshTimer.Elapsed += (s, e) => { RefreshOnlineStatus(); };
+            refreshTimer.Interval = 1 * 60 * 1000;
+        }
 
-      public static PoeTradeOnlineHelper Instance
-      {
-         get
-         {
-            if (instance == null)
-               instance = new PoeTradeOnlineHelper();
-
-            return instance;
-         }
-      }
-
-      private bool currentlyOnline;
-      private void RefreshOnlineStatus()
-      {
-         try
-         {
-            Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
-            var idleTime = GetIdleTime();
-
-            if (idleTime >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
+        public static PoeTradeOnlineHelper Instance
+        {
+            get
             {
-               // Prevent from spamming poe.xyz
-               if (currentlyOnline)
-               {
-                  using (var client = new WebClient())
-                  {
-                     var offlineUri = new Uri(refreshUri.OriginalString + "/offline");
-                     var data = new NameValueCollection();
-                     client.UploadValuesAsync(offlineUri, "POST", data);
-                  }
-               }
+                if (instance == null)
+                    instance = new PoeTradeOnlineHelper();
 
-               // User is AFK or PoE is not running.
-               currentlyOnline = false;
-               return;
+                return instance;
             }
+        }
 
-            if (!currentlyOnline)
+        private bool currentlyOnline;
+        private void RefreshOnlineStatus()
+        {
+            try
             {
-               using (var client = new WebClient())
-               {
-                  var data = new NameValueCollection();
-                  client.UploadValuesAsync(refreshUri, "POST", data);
-                  currentlyOnline = true;
-               }
+                Func<Process, bool> IsPoE = (c => c.MainWindowTitle.Contains("Path of Exile") || c.ProcessName.Contains("PathOfExile"));
+                var idleTime = GetIdleTime();
+
+                if (idleTime >= TimeSpan.FromMinutes(10) || !Process.GetProcesses().Any(IsPoE))
+                {
+                    // Prevent from spamming poe.xyz
+                    if (currentlyOnline)
+                    {
+                        using (var client = new WebClient())
+                        {
+                            var offlineUri = new Uri(refreshUri.OriginalString + "/offline");
+                            var data = new NameValueCollection();
+                            client.UploadValuesAsync(offlineUri, "POST", data);
+                        }
+                    }
+
+                    // User is AFK or PoE is not running.
+                    currentlyOnline = false;
+                    return;
+                }
+
+                if (!currentlyOnline)
+                {
+                    using (var client = new WebClient())
+                    {
+                        var data = new NameValueCollection();
+                        client.UploadValuesAsync(refreshUri, "POST", data);
+                        currentlyOnline = true;
+                    }
+                }
             }
-         }
-         catch (Exception ex)
-         {
-            Logger.Log("Error refreshing online/offline status in PoeTradeOnlineHelper: " + ex.ToString());
-         }
-      }
+            catch (Exception ex)
+            {
+                Logger.Log("Error refreshing online/offline status in PoeTradeOnlineHelper: " + ex.ToString());
+            }
+        }
 
-      private TimeSpan GetIdleTime()
-      {
-         var inputInfo = new LASTINPUTINFO()
-         {
-            cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
-            dwTime = 0
-         };
-         GetLastInputInfo(ref inputInfo);
-         // Allow for TickCount wrap-around.
-         return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - inputInfo.dwTime));
-      }
+        private TimeSpan GetIdleTime()
+        {
+            var inputInfo = new LASTINPUTINFO()
+            {
+                cbSize = (uint)Marshal.SizeOf(typeof(LASTINPUTINFO)),
+                dwTime = 0
+            };
+            GetLastInputInfo(ref inputInfo);
+            // Allow for TickCount wrap-around.
+            return TimeSpan.FromMilliseconds(unchecked(Environment.TickCount - inputInfo.dwTime));
+        }
 
-      internal void Start()
-      {
-         try
-         {
-            var enabled = Convert.ToBoolean(Settings.UserSettings["PoeTradeRefreshEnabled"]);
+        internal void Start()
+        {
+            try
+            {
+                var enabled = Convert.ToBoolean(Settings.UserSettings["PoeTradeRefreshEnabled"]);
 
-            if (!enabled || refreshTimer.Enabled)
-               return;
+                if (!enabled || refreshTimer.Enabled)
+                    return;
 
-            var poeTradeUrl = Settings.UserSettings["PoeTradeRefreshUrl"];
-            refreshUri = new Uri(poeTradeUrl);
+                var poeTradeUrl = Settings.UserSettings["PoeTradeRefreshUrl"];
+                refreshUri = new Uri(poeTradeUrl);
 
-            refreshTimer.Start();
-            RefreshOnlineStatus();
-         }
-         catch (Exception ex)
-         {
-            Logger.Log("Error starting PoeTradeOnlineHelper: " + ex.ToString());
-            MessageBox.Show("Error refreshing poe.trade online status, ensure you have a valid url entered.", "Error Starting PoeTradeOnlineHelper", MessageBoxButton.OK, MessageBoxImage.Error);
-         }
-      }
+                refreshTimer.Start();
+                RefreshOnlineStatus();
+            }
+            catch (Exception ex)
+            {
+                Logger.Log("Error starting PoeTradeOnlineHelper: " + ex.ToString());
+                MessageBox.Show("Error refreshing poe.trade online status, ensure you have a valid url entered.", "Error Starting PoeTradeOnlineHelper", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+        }
 
-      internal void Stop()
-      {
-         refreshTimer.Stop();
-      }
-   }
+        internal void Stop()
+        {
+            refreshTimer.Stop();
+        }
+    }
 }


### PR DESCRIPTION
This builds on the previous work done by Kapps in that Procurement stops the re-online call if user is idle or PoE is closed and adds the feature that the user is marked offline in either of those cases.
#### Changes
- Changed the main timer to run at a 1 minute interval instead of 30 minutes. This is to help with the granularity of marking the user as offline when PoE is closed.
- Mark the user as offline if PoE is closed or the user hasn't provided input in the last 10 minutes
- Added logic to keep track of the last time that the online status was registered with poe.trade. This operation now only occurs every 55 minutes instead of every 30 minutes.
#### Possible future enhancements:
- Allow the timeout interval to be configurable
- Run the code that detects if PoE is running when Procurement is closed. Mark the user as offline if PoE is not running.
